### PR TITLE
fix inline so -O0 works too

### DIFF
--- a/src/pixiewps.h
+++ b/src/pixiewps.h
@@ -218,7 +218,7 @@ char v_usage[] =
 	"\n";
 
 /* One digit comma separated number parsing */
-inline uint_fast8_t parse_mode(char *list, uint_fast8_t *dst, const uint8_t max_digit) {
+static inline uint_fast8_t parse_mode(char *list, uint_fast8_t *dst, const uint8_t max_digit) {
 	uint_fast8_t cnt = 0;
 	while (*list != 0) {
 		if (*list <= ((char) max_digit) + '0') {
@@ -237,7 +237,7 @@ inline uint_fast8_t parse_mode(char *list, uint_fast8_t *dst, const uint8_t max_
 }
 
 /* Checks if passed mode is selected */
-inline uint_fast8_t is_mode_selected(const uint_fast8_t mode) {
+static inline uint_fast8_t is_mode_selected(const uint_fast8_t mode) {
 	for (uint_fast8_t i = 0; p_mode[i] != NONE && i < MODE_LEN; i++) {
 		if (p_mode[i] == mode)
 			return 1;

--- a/src/utils.h
+++ b/src/utils.h
@@ -166,7 +166,7 @@ unsigned long get_elapsed_ms(struct timeval *start, struct timeval *end) {
 }
 
 /* Converts an unsigned integer to a char array without termination */
-inline void uint_to_char_array(unsigned int num, unsigned int len, uint8_t *dst) {
+static inline void uint_to_char_array(unsigned int num, unsigned int len, uint8_t *dst) {
 	unsigned int mul = 1;
 	while (len--) {
 		dst[len] = (num % (mul * 10) / mul) + '0';

--- a/src/wps.h
+++ b/src/wps.h
@@ -84,7 +84,7 @@ void kdf(const void *key, uint8_t *res) {
 }
 
 /* Pin checksum computing */
-inline uint_fast8_t wps_pin_checksum(uint_fast32_t pin) {
+static inline uint_fast8_t wps_pin_checksum(uint_fast32_t pin) {
 	unsigned int acc = 0;
 	while (pin) {
 		acc += 3 * (pin % 10);
@@ -96,12 +96,12 @@ inline uint_fast8_t wps_pin_checksum(uint_fast32_t pin) {
 }
 
 /* Validity PIN control based on checksum */
-inline uint_fast8_t wps_pin_valid(uint_fast32_t pin) {
+static inline uint_fast8_t wps_pin_valid(uint_fast32_t pin) {
 	return wps_pin_checksum(pin / 10) == (pin % 10);
 }
 
 /* Checks if PKe == 2 */
-inline uint_fast8_t check_small_dh_keys(const uint8_t *data) {
+static inline uint_fast8_t check_small_dh_keys(const uint8_t *data) {
 	uint_fast8_t i = WPS_PKEY_LEN - 2;
 	while (--i) {
 		if (data[i] != 0)


### PR DESCRIPTION
basically "inline" used by itself prevents compilation without optimization turned on, with "static inline" it works everywhere